### PR TITLE
feat(seo): Adiciona meta tag de verificação do Google Search Console

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+        env:
+          GSC_VERIFICATION_CODE: ${{ secrets.GSC_VERIFICATION_CODE }}
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
@@ -43,4 +45,4 @@ jobs:
           path: './build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -410,10 +410,11 @@ const config: Config = {
         content:
           "n8n Brasil - Documentação não oficial em Português Brasileiro",
       },
-      {
+      // Adiciona a tag de verificação do Google apenas em produção
+      ...process.env.GSC_VERIFICATION_CODE ? [{
         name: "google-site-verification",
-        content: "cPczfCn6ukej2JyY3E23bL9VN5ChEtWJ-TQHLYrlam8"
-      }
+        content: process.env.GSC_VERIFICATION_CODE,
+      }] : [],
     ],
   },
 } satisfies Config;

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -410,6 +410,10 @@ const config: Config = {
         content:
           "n8n Brasil - Documentação não oficial em Português Brasileiro",
       },
+      {
+        name: "google-site-verification",
+        content: "cPczfCn6ukej2JyY3E23bL9VN5ChEtWJ-TQHLYrlam8"
+      }
     ],
   },
 } satisfies Config;


### PR DESCRIPTION
Este commit adiciona a meta tag de verificação do Google Search Console (GSC) diretamente no arquivo .

A verificação da propriedade do site é um passo crucial para habilitar o monitoramento de desempenho, solicitar a indexação de páginas e diagnosticar problemas de SEO através das ferramentas do Google.

A abordagem via meta tag foi escolhida por ser mais limpa e manter toda a configuração de metadados centralizada, alinhada com as melhores práticas do Docusaurus.