### PR TITLE
docs(deploy): adicionar script deploy:pages e instruções de deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ npm run build
 
 # Servir build de produção
 npm run serve
+
+# Deploy para GitHub Pages
+# PowerShell (Windows)
+$env:GIT_USER='SEU_USUARIO_GITHUB'; npm run deploy:pages
+# Linux/macOS
+GIT_USER=SEU_USUARIO_GITHUB npm run deploy:pages
 ```
 
 ### Solução de Problemas

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
+    "deploy:pages": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
- Adiciona script npm \deploy:pages\ para publicar no GitHub Pages.\n- Documenta no README como realizar o deploy (Windows/Linux/macOS).\n- Mantém publicação em \gh-pages\ com \aseUrl\ já configurado.