### PR TITLE
ci: desativar fail-fast na matriz Node 18/20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18.x, 20.x]
     


### PR DESCRIPTION
Evita cancelamento prematuro do job validate-and-build (20.x) quando a matriz inclui 18.x e um job falha/cancela. Isso melhora a observabilidade do pipeline e reduz falsos negativos.

- Adicionado: strategy.fail-fast: false
- Workflow: CI/CD Pipeline (ci.yml)